### PR TITLE
Fix key bindings not working in built .app

### DIFF
--- a/HappyHackingKeybinder/Resources/Info.plist
+++ b/HappyHackingKeybinder/Resources/Info.plist
@@ -26,5 +26,20 @@
     <true/>
     <key>NSHumanReadableCopyright</key>
     <string>Copyright © 2024 HappyHacking Keybinder. All rights reserved.</string>
+    <key>NSPrivacyAccessedAPITypeReasons</key>
+    <array>
+        <dict>
+            <key>NSPrivacyAccessedAPIType</key>
+            <string>NSPrivacyAccessedAPICategoryInputMonitoring</string>
+            <key>NSPrivacyAccessedAPITypeReasons</key>
+            <array>
+                <string>3B52.1</string>
+            </array>
+        </dict>
+    </array>
+    <key>NSSystemAdministrationUsageDescription</key>
+    <string>HappyHacking Keybinder needs accessibility permission to monitor and remap keyboard inputs for Happy Hacking Keyboard devices.</string>
+    <key>NSInputMonitoringUsageDescription</key>
+    <string>HappyHacking Keybinder needs input monitoring permission to detect and remap key presses from your Happy Hacking Keyboard.</string>
 </dict>
 </plist>

--- a/build.sh
+++ b/build.sh
@@ -15,9 +15,9 @@ if [ $? -eq 0 ]; then
     # Copy the simple executable like swift run does
     cp .build/release/HappyHackingKeybinder ./HappyHackingKeybinder_simple
     
-    # Sign it like swift does (simple adhoc signing with stable identifier)
+    # Sign it like swift does (simple adhoc signing with entitlements and stable identifier)
     echo "Signing simple executable..."
-    codesign --force --sign - --identifier "HappyHackingKeybinder" ./HappyHackingKeybinder_simple
+    codesign --force --sign - --entitlements simple.entitlements --identifier "HappyHackingKeybinder" ./HappyHackingKeybinder_simple
     
     echo "Simple executable created: ./HappyHackingKeybinder_simple"
     echo "✅ This version works! Run it with: ./HappyHackingKeybinder_simple"
@@ -35,9 +35,9 @@ if [ $? -eq 0 ]; then
     # Create icon (placeholder for now)
     touch HappyHackingKeybinder.app/Contents/Resources/AppIcon.icns
     
-    # Ad-hoc code signing with stable identifier (like swift run)
+    # Ad-hoc code signing with entitlements and stable identifier (like swift run)
     echo "Signing app..."
-    codesign --force --deep --sign - --identifier "HappyHackingKeybinder" HappyHackingKeybinder.app
+    codesign --force --deep --sign - --entitlements HappyHackingKeybinder.entitlements --identifier "HappyHackingKeybinder" HappyHackingKeybinder.app
     
     if [ $? -eq 0 ]; then
         echo "App signed successfully!"


### PR DESCRIPTION
Fixes #1

## Summary
- Add privacy usage descriptions to Info.plist for input monitoring
- Apply entitlements during code signing in build.sh
- Fixes issue where key bindings worked with swift run but not in .app

## Test plan
- [ ] Build the app with `./build.sh`
- [ ] Run the .app bundle and verify key bindings work
- [ ] Test that accessibility and input monitoring permissions are properly requested

🤖 Generated with [Claude Code](https://claude.ai/code)